### PR TITLE
Add loop for search engines in index

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -2,21 +2,17 @@
 
 <h1 class="welcomeText">{{ .Site.Params.welcomeText }}</h1>
 
-{{ if .Site.Params.showGoogleSearch }}
-<form id="search-form-g" action="https://www.google.com/search" method="get">
-    <input id="search-bar" class="form-control" type="text" autofocus type="text" placeholder="Search Google" name="q" alt="Search Google" onkeydown="if(event.keyCode === 13) { this.form.submit(); return false; }">
-</form>
+
+{{ if .Site.Params.searchEngines }}
+    {{ range .Site.Params.searchEngines }}
+        {{ if .activated }}
+            <form id="search-form-{{ .name }}" class="mb-3" action="{{ .url }}" method="get">
+                <input id="search-bar-{{ .name }}" class="form-control" type="text" autofocus type="text" placeholder="Search {{ .name }}" name="q" alt="Search {{ .name }}" onkeydown="if(event.keyCode === 13) { this.form.submit(); return false; }">
+            </form>
+        {{ end }}
+    {{ end }}
 {{ end }}
-{{ if .Site.Params.showBingSearch }}
-<form id="search-form-b" action="https://www.bing.com/search" method="get">
-    <input id="search-bar" class="form-control" type="text" autofocus type="text" placeholder="Search Bing" name="q" alt="Search Bing" onkeydown="if(event.keyCode === 13) { this.form.submit(); return false; }">
-</form>
-{{ end }}
-{{ if .Site.Params.showDuckDuckGoSearch }}
-<form id="search-form-ddg" action="https://duckduckgo.com/" method="get">
-    <input id="search-bar" class="form-control" type="text" autofocus type="text" placeholder="Search DuckDuckGo" name="q" alt="Search DuckDuckGo" onkeydown="if(event.keyCode === 13) { this.form.submit(); return false; }">
-</form>
-{{ end }}
+
 
 {{ if .Site.Params.startPageColumns }}
     <div id="groupList" class="card-deck mt-3">


### PR DESCRIPTION
Hi, what do you think about removing search engine field conditions in index and replace it by a loop ? 

At the moment, each search engine have to be defined in params and have a condition in index html. 
So if someone wants to add his / her new search engine, he / she has to create a new condition in html file. 

So with this loop, user just have to register the new search engine in configuration and the search bar will be displayed.

The configuration file could be similar to this one. 
```
---
  searchEngines:
    - name: "Google"
      activated: true
      url: "https://www.google.com/search"
    - name: "DuckDuckGo"
      activated: true
      url: "https://duckduckgo.com/"
```